### PR TITLE
Update openHAB.sh for more reliable restarts.

### DIFF
--- a/shared/openHAB.sh
+++ b/shared/openHAB.sh
@@ -109,7 +109,7 @@ function setupEnvironment {
 
         # Is there JAVA_HOME?
         JAVA_HOME=/usr/local/jre
-        if [ ! -d ${JAVA_HOME} ]; then
+        if [ ! -e ${JAVA_HOME} ]; then
             log_tool -t 1 -a "Java not found! Please read the documentation about details."
             exit 1
         fi
@@ -178,8 +178,8 @@ case "$1" in
 #    fi
 
     # Detecting PID of current instance while looking at instance.properties
-    if [ -f ${QPKG_DISTRIBUTION}/runtime/karaf/instances/instance.properties ]; then
-        QPKG_PID=$(sed -n -e '/item.0.pid/ s/.*\= *//p' ${QPKG_DISTRIBUTION}/runtime/karaf/instances/instance.properties)
+    if [ -f ${QPKG_DISTRIBUTION}/runtime/instances/instance.properties ]; then
+        QPKG_PID=$(sed -n -e '/item.0.pid/ s/.*\= *//p' ${QPKG_DISTRIBUTION}/runtime/instances/instance.properties)
         # Checking whether PID is still running
         if [ x${QPKG_PID} != "x" ]; then
             if [ -f /proc/${QPKG_PID}/status ] ; then
@@ -219,6 +219,12 @@ case "$1" in
 
     # TODO: WORKAROUND: Waiting one minute until the service is properly turned off
     sleep 60
+    # If openHAB not really running, then it's ok to remove the instance.properties file
+    ps -ef | grep java | grep openHAB | grep -v grep
+    if [ $? != 0 ]; then
+        rm ${QPKG_DISTRIBUTION}/runtime/instances/instance.properties
+    fi
+
     ;;
 
   restart)


### PR DESCRIPTION
Changes to make openHAB restart more reliably.
I found under Qnap 4.3.4 there were 2 reasons that openHAB 2.0.0 won't start.
First reason would show up in logs as: "Java not found! Please read the documentation about details."
Second reason was issues with instance.properties file was both looked for in wrong path, and also not being removed. 3 changes were made:
1. The old -d check for JAVA_HOME doesn't always work if directory is a link, use -e instead.
2. Actual path to instance.properties file changed it seems, karaf was dropped from pathname.
3. Removes instance.properties file after verifying process is not running.

Attempts to fix #31 #46 #47